### PR TITLE
version up tmux

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -21,7 +21,7 @@ bind Space next-window                    # 次のウィンドウに移動
 bind i display-panes                      # ペイン番号表示
 bind b break-pane                         # 選択中のペインをウィンドウに分離
 bind - split-window -v                    # ペインの横分割
-bind \ split-window -h                    # ペインの縦分割
+bind \\ split-window -h                   # ペインの縦分割
 # ペインの移動
 bind h select-pane -L
 bind j select-pane -D

--- a/tmux.conf
+++ b/tmux.conf
@@ -48,7 +48,5 @@ set-option -g status-right "#(~/dotfiles/tmux/tmux-powerline/powerline.sh right)
 set-window-option -g window-status-current-format "#[fg=colour235, bg=colour27]⮀#[fg=colour255, bg=colour27] #I ⮁ #W #[fg=colour27, bg=colour235]⮀"
 
 # 色
-set -g message-bg colour255
-set -g message-fg colour000
-set -g pane-active-border-bg colour000
-set -g pane-active-border-fg colour255
+set -g message-style bg="colour255",fg="colour000"
+set -g pane-active-border-style bg="colour000",fg="colour255"

--- a/tmux/my-tmux-powerline/themes/mytheme.sh
+++ b/tmux/my-tmux-powerline/themes/mytheme.sh
@@ -47,7 +47,7 @@ if [ -z $TMUX_POWERLINE_RIGHT_STATUS_SEGMENTS ]; then
 		"load 237 167" \
 		#"tmux_mem_cpu_load 234 136" \
 		#"battery 137 127" \
-		"weather 37 255" \
+		#"weather 37 255" \
 		#"rainbarf 0 0" \
 		#"xkb_layout 125 117" \
 		"date_day 235 136" \


### PR DESCRIPTION
- `\` の bind が正しく動かなくなったので修正
  - https://github.com/tmux/tmux/issues/1827
- 2.8 -> 2.9 で下位互換性のない修正が入ったので対応
  - https://qiita.com/TsutomuNakamura/items/663b8e456768f29e37ed
  - https://github.com/tmux/tmux/issues/1689
- powerline の天気情報が利用できなくなった (yahoo api の提供終了) ので非表示にした
  - https://github.com/erikw/tmux-powerline/issues/219