### PR TITLE
extract tmux version correctly

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -1,5 +1,5 @@
 # バージョン取得
-run-shell "tmux setenv -g TMUX_VERSION $(tmux -V | cut -c 6-)"
+run-shell "tmux setenv -g TMUX_VERSION $(tmux -V | sed 's/[^0-9\.]//g')"
 
 # 基本設定
 set -g bell-action none     # 全てのベルを無視


### PR DESCRIPTION
tmux をソースから直接インストールすると，6 文字目以降をバージョンとみなすこれまでのルールが効かなくなるので修正。
```bash
$ tmux -V
tmux 3.0

$ tmux -V
tmux next-3.2
```